### PR TITLE
Improve Jekyll generator for gorelated

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,20 +42,28 @@ Jekyll Module:
 
     module Reading
       class Generator < Jekyll::Generator
+        require 'csv' 
+        
         def generate(site)
-          #Prepare a list of posts that will be processed by the Go program
-          url  = Jekyll.configuration({})['url']
-          listPath = File.join(site.source, '_data', 'posts.txt')
-          file = File.new(listPath, "w")
-          site.posts.each do |post|
-            if post.data['published']
-              file.write(url + post.url + "," + post.path  + ",\"" + post.data['title'] + "\",\"" + post.data['description'] + " \"," + post.data['thumbnail'] + "\n")
+          # Prepare a list of posts that will be processed by the Go program
+          url  = site.config['url']
+          listPath = site.in_source_dir('_data', 'posts.txt')
+          CSV.open(listPath, "wb") do |csv|
+            site.posts.each do |post|
+              if site.publisher.publish? post
+                csv << [
+                  url + post.url,
+                  post.path,
+                  "\"#{post.data['title']}\"",
+                  "\"#{post.data['description']}\"",
+                  post.data['thumbnail']
+                ]
+              end
             end
           end
-          file.close
-          #Call the Go program that will process the list and generate a JSON file
-          exePath = File.join(site.source, '_data', 'gorelated')
-          system exePath + " -jekyll \"" + listPath + "\""
+          # Call the Go program that will process the list and generate a JSON file
+          exePath = site.in_source_dir('_data', 'gorelated')
+          system exePath, "-jekyll", listPath
         end
       end
     end
@@ -81,7 +89,7 @@ From this point, the JSON file can be used by Liquid tags, for example:
       {% endfor %}
     </div>
 
-# Dependancies
+# Dependencies
 
 * https://github.com/bbalet/stopwords Libray cleaning the stop words, HTML tags and duplicated spaces in a content
 * https://github.com/kardianos/osext get the folder where the executable is installed (not running)

--- a/readme.md
+++ b/readme.md
@@ -54,9 +54,9 @@ Jekyll Module:
                 csv << [
                   url + post.url,
                   post.path,
-                  "\"#{post.data['title']}\"",
-                  "\"#{post.data['description']}\"",
-                  post.data['thumbnail']
+                  post.to_liquid['title'],
+                  post.to_liquid['description'],
+                  post.to_liquid['thumbnail']
                 ]
               end
             end


### PR DESCRIPTION
Hey, @bbalet! Great job getting this up and running with Jekyll. I had some ideas for improvements to the generator:
- Use `csv` library to write CSV output (handles proper quoting, etc)
- Instead of checking `post.data['published']`, use the `Jekyll::Publisher` which encapsulates logic for publishing
- Pass args to `system` instead of one string
- Use `site.config['url']` because the site already has the URL all figured out
- Use `Post#to_liquid` to fetch metadata like title and so forth. This is more forwards-compatible.
